### PR TITLE
Fix build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GXX=g++ -std=c++11
 #OPTM=-O3 -msse2 -msse4 -fopenmp
 OPTM=-O3 -march=native -fopenmp
 CPFLAGS=$(OPTM) -Wall -DINFO
-LDFLAGS=$(OPTM) -Wall -lboost_timer -lboost_system -DINFO
+LDFLAGS=$(OPTM) -Wall -lboost_timer -lboost_chrono -lboost_system -DINFO
 
 INCLUDES=-I./ -I./algorithm -I./general
 
@@ -22,7 +22,7 @@ all: $(SHARED_LIB) $(SAMPLES)
 #	$(GXX) $(LDFLAGS) $(LIBS) $(OBJS) -shared -o $(SHARED_LIB)
 
 $(SAMPLES): %: %.o
-	$(GXX) $(LDFLAGS) $(LIBS) $^ -o $@
+	$(GXX) $^ -o $@ $(LDFLAGS) $(LIBS)
 
 %.o: %.cpp $(HEADERS)
 	$(GXX) $(CPFLAGS) $(INCLUDES) -c $*.cpp -o $@

--- a/algorithm/kdtreeub_index.hpp
+++ b/algorithm/kdtreeub_index.hpp
@@ -1048,7 +1048,7 @@ public:
 					DataType dist = distance_->compare(
 							features_.get_row(tmpfea), features_.get_row(feature_id), features_.get_cols());
 
-					{LockGuard g(nhoods[tmpfea].lock);
+					{LockGuard g(*nhoods[tmpfea].lock);
 					if(knn_graph[tmpfea].size() < params_.S || dist < knn_graph[tmpfea].begin()->distance){
 						Candidate<DataType> c1(feature_id, dist);
 						knn_graph[tmpfea].insert(c1);
@@ -1062,7 +1062,7 @@ public:
 
 					}
 					}
-					{LockGuard g(nhoods[feature_id].lock);
+					{LockGuard g(*nhoods[feature_id].lock);
 					if(knn_graph[feature_id].size() < params_.S || dist < knn_graph[feature_id].begin()->distance){
 						Candidate<DataType> c1(tmpfea, dist);
 						knn_graph[feature_id].insert(c1);


### PR DESCRIPTION
- boost_timer required boost_chrono
- the Neighbor class was not moveable since it contained
  a Lock object that wasn't. Fixed using a pointer to the
  lock object instead.